### PR TITLE
Add NTP and VPC capability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,25 @@ This is a [Packer](https://packer.io/) template. Install the latest version of
 Packer, then:
 
     packer build \
-      -var docker_version=1.6.0 \
+      -var docker_version=1.6.2 \
       -var source_ami=ami-d05e75b8 \
       -var aws_region=$AWS_REGION \
       -var aws_access_key=$AWS_ACCESS_KEY_ID \
       -var aws_secret_key=$AWS_SECRET_ACCESS_KEY \
       docker-ami.json
+
+For VPC:
+
+    packer build \
+      -var docker_version=1.6.2 \
+      -var source_ami=ami-<id> \
+      -var instance_type=m3.medium \
+      -var aws_region=$AWS_REGION \
+      -var aws_access_key=$AWS_ACCESS_KEY_ID \
+      -var aws_secret_key=$AWS_SECRET_ACCESS_KEY \
+      -var vpc_id=vpc-<id> \
+      -var subnet_id=subnet-<id> \
+      docker-ami-vpc.json
+
 
 This will chew for a bit and finally output the AMI ID.

--- a/docker-ami-vpc.json
+++ b/docker-ami-vpc.json
@@ -1,0 +1,38 @@
+{
+  "description": "Docker-capable AMI for Amazon EC2",
+
+  "variables": {
+    "aws_access_key": "",
+    "aws_secret_key": "",
+    "aws_region": "",
+    "ami_description": "",
+    "docker_version": "1.6.0",
+    "source_ami": "",
+    "instance_type": "t2.micro",
+    "vpc_id": "",
+    "subnet_id": ""
+  },
+
+  "builders": [{
+    "type": "amazon-ebs",
+    "access_key": "{{user `aws_access_key`}}",
+    "secret_key": "{{user `aws_secret_key`}}",
+    "ami_description": "{{user `ami_description`}}",
+    "region": "{{user `aws_region`}}",
+    "source_ami": "{{user `source_ami`}}",
+    "instance_type": "{{user `instance_type`}}",
+    "ssh_username": "ubuntu",
+    "ami_name": "docker-{{user `docker_version`}} ({{timestamp}})",
+    "vpc_id": "{{user `vpc_id`}}",
+    "subnet_id": "{{user `subnet_id`}}",
+    "associate_public_ip_address": true
+  }],
+
+  "provisioners": [{
+    "type": "shell",
+    "environment_vars": [
+      "docker_version={{user `docker_version`}}"
+    ],
+    "scripts": ["provision.sh"]
+  }]
+}

--- a/docker-ami.json
+++ b/docker-ami.json
@@ -18,7 +18,10 @@
     "source_ami": "{{user `source_ami`}}",
     "instance_type": "{{user `instance_type`}}",
     "ssh_username": "ubuntu",
-    "ami_name": "docker-{{user `docker_version`}} ({{timestamp}})"
+    "ami_name": "docker-{{user `docker_version`}} ({{timestamp}})",
+    "vpc_id": "{{user `vpc_id`}}",
+    "subnet_id": "{{user `subnet_id`}",
+    "associate_public_ip_address": "{{user `public_ip`}}"
   }],
 
   "provisioners": [{

--- a/provision.sh
+++ b/provision.sh
@@ -21,6 +21,7 @@ echo 'deb http://get.docker.io/ubuntu docker main' \
 
 apt-get -y update
 apt-get -y upgrade
+apt-get -y install ntp
 apt-get -y install linux-image-extra-$(uname -r)
 apt-get -y install lxc-docker-$version
 


### PR DESCRIPTION
I have found d11wtq/docker-ami-packer useful and wanted to contribute a couple things that we have needed.

1)  Inside the VPC our hvm instances drift up to a few seconds after weeks of uptime, so have ntp present in all cases is helpful.

2) Build a docker host AMI inside the VPC.
